### PR TITLE
Make it easy to try models in NetLogo Web

### DIFF
--- a/app/assets/javascripts/nlcommons.js
+++ b/app/assets/javascripts/nlcommons.js
@@ -525,7 +525,15 @@ jQuery.fn.dataTableExt.oPagination.two_button_full_text = {
 	    
 	});
     };
-    
+
+	var initializeModelClickToLoadNLW = function() {
+	$("#model_click_to_load_nlw").click(function(e) {
+		var elem = e.srcElement;
+		elem.classList.remove('model_placeholder');
+		elem.innerHTML = "<iframe class='nlw_model_frame' src='" + elem.dataset.modelUrl + "'></iframe>";
+	});
+    };
+
     var initializeModelPermissionsChanger = function() {
 	var select_no_group_enable = function(enable) {
 	    if(enable) {
@@ -1129,6 +1137,7 @@ jQuery.fn.dataTableExt.oPagination.two_button_full_text = {
     	initializeSearchTabs();
     	initializeGroupInvitationPersonSelector();
     	initializeModelClickToLoad();
+    	initializeModelClickToLoadNLW();
     	initializeModelPermissionsChanger();
     	initializeHeaderLoginForm();
     	initializeNewCommentForm();

--- a/app/assets/stylesheets/nlcommons.scss
+++ b/app/assets/stylesheets/nlcommons.scss
@@ -738,7 +738,7 @@ $image-padding: 4px;
    font-weight: bold;
 }
 
-#model_click_to_load {
+.model_placeholder {
    background-color: hsl(0%, 0%, 85%);
    display: block;
    cursor: pointer;
@@ -750,6 +750,18 @@ $image-padding: 4px;
    line-height: 500px;
    
 }
+
+.nlw_model_container {
+  height: 800px;
+  line-height: 800px;
+  width: 100%;
+}
+
+.nlw_model_frame {
+  height: 100%;
+  width: 100%;
+}
+
 #model_applet {
    display: none;
 }

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -60,6 +60,7 @@ class BrowseController < ApplicationController
   end
 
   def model_contents
+    headers['Access-Control-Allow-Origin'] = '*'
     @model = Node.find(params[:id]) if params[:id].present?
     send_data @model.contents
   end

--- a/app/views/browse/_browse_applet_tab.html.erb
+++ b/app/views/browse/_browse_applet_tab.html.erb
@@ -7,7 +7,7 @@
   <p>Sorry, but this model cannot be viewed as an applet.  You must <%= link_to "download it", :controller => :browse, :action => :download_model, :id => @model.id -%> and run it within NetLogo on your local computer.</p>
   <% else %>
   <!-- browse_applet_tab -->
-  <div id="model_click_to_load"  >
+  <div id="model_click_to_load" class="model_placeholder">
   	Click to Run Model
   </div>
   <div id="model_container" class="model_container">

--- a/app/views/browse/_browse_nlw_tab.html.erb
+++ b/app/views/browse/_browse_nlw_tab.html.erb
@@ -1,0 +1,14 @@
+<div>
+
+  <% if @model.cannot_be_run_as_applet? and @person and !@person.administrator? %>
+  <p>Sorry, but this model cannot be run in NetLogo Web.  You must <%= link_to "download it", :controller => :browse, :action => :download_model, :id => @model.id -%> and run it within NetLogo on your local computer.</p>
+  <% else %>
+
+  <!-- browse_nlw_tab -->
+  <div id="model_click_to_load_nlw" class="model_placeholder nlw_model_container" data-model-url="//netlogoweb.org/web?url=<%= model_contents_url(:id => @model.id)  -%>&name=<%= @model.name -%>">
+    Click to Run Model
+  </div>
+
+  <% end %>
+
+</div>

--- a/app/views/browse/one_model.html.erb
+++ b/app/views/browse/one_model.html.erb
@@ -179,7 +179,8 @@
       <ul>
 	<li><a href="#browse_info">Info</a></li>
 	<li><a href="#browse_discuss">Discuss</a></li>
-	<li><a href="#browse_applet">Run</a></li>
+	<li><a href="#browse_applet">Run as Applet</a></li>
+	<li><a href="#browse_nlw">Run in NetLogo Web</a></li>
 	<li><a href="#browse_procedures">Code</a></li>
 	<li><a href="#browse_history">History</a></li>
 	<li><a href="#browse_files">Files</a></li>
@@ -196,6 +197,9 @@
       </div>
       <div id="browse_applet">
 	<%= render :partial => "/browse/browse_applet_tab" %>
+      </div>
+      <div id="browse_nlw">
+	<%= render :partial => "/browse/browse_nlw_tab" %>
       </div>
       <div id="browse_procedures">
 	<%= render :partial => "/browse/browse_procedures_tab" %>


### PR DESCRIPTION
Howdy Reuven!

I felt so left out upon seeing how much fun you were having as the maintainer of the Modeling Commons recently that I decided to take it upon myself to try being the maintainer of my own local version of the Modeling Commons.

:tada: :tada: :tada:

This pull request adds a tab to model pages for running models in NetLogo Web.  This is something that's valuable to us in the CCL, especially since applets have become so unpleasant to use.  

That said, I think there are couple of things worth bringing to your attention about this PR:

First, since there are now two "Run" tabs (one for applets and one for NLW), I changed the names of the tabs to "Run as Applet" and "Run in NetLogo Web".  This causes the tab list to overflow onto a second line, which, admittedly, doesn't look nice.

![mc_nlw](https://cloud.githubusercontent.com/assets/912890/15346452/f284be34-1c7d-11e6-9bf0-f982137d0057.png)

On the topic of applets, do you have any metrics—I'm guessing not—on how many people actually use the applets tab?  Because if no one's using the applets, we think the best thing would just be to get rid of the applets support altogether.  That would also address this verbosity problem that I introduced with the tab titles.  If people _are_ using them, though, then we probably need some other (relatively simple) solution for this UI/layout problem.

The other big thing is that I added a statement of `headers['Access-Control-Allow-Origin'] = '*'` when serving up `.nlogo` files.  Naturally, this means that any site in the universe can hit the Modeling Commons to download models.  I would expect that to not be a problem, but maybe you don't like that.  If it's the latter, then, in order for this PR to work, we would need to change it to only allow `http://netlogoweb.org`, `http://netlogo-web.org`, and the `https://` variants of both of those, as well.  Not a huge deal, but something to be aware of.

That's it from me, though.  Hopefully you think this PR is :heart:—I _did_ try to match your style as much as reasonably possible—but, of course, feel free to let me know anything here that makes you feel :fire: or :imp:, or maybe even a little :fu:, and I'll be glad to make changes as necessary.
