### PR TITLE
Bugfix: URL escape model names for NLW

### DIFF
--- a/app/views/browse/_browse_nlw_tab.html.erb
+++ b/app/views/browse/_browse_nlw_tab.html.erb
@@ -5,7 +5,7 @@
   <% else %>
 
   <!-- browse_nlw_tab -->
-  <div id="model_click_to_load_nlw" class="model_placeholder nlw_model_container" data-model-url="//netlogoweb.org/web?url=<%= model_contents_url(:id => @model.id)  -%>&name=<%= @model.name -%>">
+  <div id="model_click_to_load_nlw" class="model_placeholder nlw_model_container" data-model-url="//netlogoweb.org/web?url=<%= model_contents_url(:id => @model.id) -%>&name=<%= CGI.escape @model.name -%>">
     Click to Run Model
   </div>
 


### PR DESCRIPTION
I recently discovered that it's not safe for us to just write the model's name into the URL, in case it contains, for example, `%` characters, which will throw off the URL decoding in NLW.

Not urgent.