### PR TITLE
Set all avatar names to `avatar.png` and validate file is image

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -12,7 +12,6 @@ class Person < ActiveRecord::Base
   has_many :spam_warnings
   has_many :projects
   has_many :non_member_collaborations
-
   has_many :versions
   has_many :attachments
 
@@ -44,6 +43,7 @@ class Person < ActiveRecord::Base
     :content_type => ["image/jpeg", "image/png", "image/gif"]
   validates_attachment_size :avatar, :less_than => 5.megabytes
   validate :avatar_is_image
+  before_post_process :normalize_avatar_filename
 
   validates_email :email_address, :level => 1
 
@@ -271,6 +271,13 @@ class Person < ActiveRecord::Base
     rescue
       errors.add(:avatar, "must be a valid image")
     end
+  end
+
+  def normalize_avatar_filename
+    return unless avatar && avatar.queued_for_write[:original]
+    ext = File.extname(avatar.queued_for_write[:original].original_filename.to_s).downcase
+    ext = ".jpg" if ext.blank?
+    self.avatar_file_name = "avatar#{ext}"
   end
 
   def tweet_person

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -40,7 +40,7 @@ class Person < ActiveRecord::Base
   validates :email_address, :uniqueness => { :case_sensitive => false }
 
   validates_attachment_content_type :avatar,
-    :content_type => ["image/jpeg", "image/png", "image/gif"]
+    :content_type => ["image/jpeg", "image/png", "image/gif", "image/jpg"]
   validates_attachment_size :avatar, :less_than => 5.megabytes
   validate :avatar_is_image
   before_post_process :normalize_avatar_filename

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -25,8 +25,9 @@ class Person < ActiveRecord::Base
   has_attached_file :avatar,
   :styles => { :medium => "200x200>", :thumb => "40x40>" },
   :default_url => "/assets/default-person/:style/default-person.png",
-  :path => ":rails_root/public/system/:attachment/:id/:style/:filename",
-  :url => "/system/:attachment/:id/:style/:filename"
+  :path => ":rails_root/public/system/:attachment/:id/:style/avatar.:extension",
+  :url => "/system/:attachment/:id/:style/avatar.:extension",
+  :hash_secret => SALT_SECRET
 
   attr_protected :avatar_file_name, :avatar_content_type, :avatar_size
 
@@ -38,6 +39,11 @@ class Person < ActiveRecord::Base
   validates :registration_consent, :presence => { :message => "must be checked" }
   validates :password, :presence => true, :confirmation => true
   validates :email_address, :uniqueness => { :case_sensitive => false }
+
+  validates_attachment_content_type :avatar,
+    :content_type => ["image/jpeg", "image/png", "image/gif"]
+  validates_attachment_size :avatar, :less_than => 5.megabytes
+  validate :avatar_is_image
 
   validates_email :email_address, :level => 1
 
@@ -254,6 +260,16 @@ class Person < ActiveRecord::Base
           self.send("#{name}=".to_sym, attributes[name].gsub($1, "&amp;#{bad_word}"))
         end
       end
+    end
+  end
+
+  def avatar_is_image
+    return unless avatar && avatar.queued_for_write[:original]
+    begin
+      require 'RMagick' unless defined?(Magick)
+      Magick::Image.read(avatar.queued_for_write[:original].path).first
+    rescue
+      errors.add(:avatar, "must be a valid image")
     end
   end
 


### PR DESCRIPTION
> ⚠️ Caution: This will break all existing images. Remedy that by renaming all images to `avatar.<ext>`.

This PR introduces the following:

1. Source avatars from `avatar.<ext>` without checking `avatar_file_name`
2. Save new `avatar_file_name` as `avatar.<ext>` independent of user filename.
3. Enforce image size `<5MB` and file is of type `jpg,jpeg,png,gif` on new uploads