### PR TITLE
Fix Account Password Encryption Related Issues

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -310,10 +310,10 @@ class AccountController < ApplicationController
     if params[:person][:password].blank?
       params[:person].delete(:password)
       params[:person].delete(:password_confirmation)
+    else
+      params[:person][:password] = Person.encrypted_password(@person.salt, params[:person][:password])    
+      params[:person][:password_confirmation] = Person.encrypted_password(@person.salt, params[:person][:password_confirmation])    
     end
-
-    params[:person][:password] = Person.encrypted_password(@person.salt, params[:person][:password])    
-    params[:person][:password_confirmation] = Person.encrypted_password(@person.salt, params[:person][:password_confirmation])    
 
     begin
       @person.update_attributes!(params[:person])

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -48,6 +48,7 @@ class Person < ActiveRecord::Base
 
   # after_validation_on_create :generate_salt_and_encrypt_password
   # after_validation_on_update :encrypt_updated_password
+  before_create :generate_salt_and_encrypt_password
 
   after_create :transform_nonmember_collaborations
   after_create :tweet_person


### PR DESCRIPTION
This PR fixes the following issues:
1- Before, when creating an account, passwords are stored as plain text. Now, it gets encrypted.
2- When editing an account, leaving passwords blank would cause a re-encryption to kick in. This breaks login since it tries to encrypt an already encrypted password as if it was plaintext.

Test scenarios conducted:
- [x] Create account with password. Log out. Log in with password. Expect to log in. 
- [x] Edit account without changing password. Log out. Log in with original password. Expect to log in.
- [x] Edit account with new password. Log out. Log in with new password. Expect to log in.
- [x] Query `people` in the DB after account is created. Expect to see a hash for password.
- [x] Query `people` in the DB after account is edited. Expect salt to remain the same.